### PR TITLE
Remove reference to already removed refresh_rmc_and_interface module

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -143,7 +143,6 @@ cloud_final_modules:
  - mcollective
  - salt-minion
  - reset_rmc
- - refresh_rmc_and_interface
  - rightscale_userdata
  - scripts-vendor
  - scripts-per-once


### PR DESCRIPTION
refresh_rmc_and_interface module was dropped in GH-PR #2148 

ddb0721259f406 ("config: drop refresh_rmc_and_interface as RHEL 7 no longer supported")

Remove stale reference to it in `ds_identify` unit test.

## Summary by Sourcery

Tests:
- Remove 'refresh_rmc_and_interface' from the list of modules in the ds_identify unit test